### PR TITLE
Introducing serializer support, moving set to use mset, and documentation updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 coverage/
 node_modules/
 .vscode/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ A modern SQlite cache store for [node-cache-manager](https://github.com/BryanDon
  - `async`/`await` support with Promise
  - 100% test coverage and production ready
  - Optimized `mset`/`mget` support
- - CBOR efficient and fast storage
+ - Supports CBOR for efficient and fast storage (selectable between `json` or `cbor` default: `json`)
+ - Support for custom serializers
  - Smart purging support, no configuration required
 
 ## Installation
@@ -22,13 +23,16 @@ npm i cache-manager-sqlite
 
 ## Usage
 
+## Single store
 ```js
 const sqliteStore = require('cache-manager-sqlite')
 const cacheManager = require('cache-manager')
 
 // SQLite :memory: cache store
 const memStoreCache = cacheManager.caching({
-    store: sqliteStore
+    store: sqliteStore,
+    serializer: 'cbor', // default is 'json'
+    ttl: 20 // TTL in seconds
 })
 
 // On disk cache on employees table
@@ -39,9 +43,40 @@ const cache = cacheManager.caching({
 })
 
 
-await cache.set('foo', {test: 'bar'}, {ttl: 10000})
-const valu = await cache.get('foo')
-// value = {test: 'bar'} here
+// TTL in seconds
+await cache.set('foo', {test: 'bar'}, {ttl: 10})
+const value = await cache.get('foo')
+```
+
+### Multi-store example:
+
+```js
+const cacheManager = require('cache-manager')
+const redisStore = require('cache-manager-ioredis')
+const sqliteStore = require('cache-manager-sqlite')
+
+const redisCache = cacheManager.caching({ store: redisStore, db: 0, ttl: 600 })
+const sqliteCache = cacheManager.caching({ store: sqliteStore, path: '/cache.db', name: 'users', ttl: 600 })
+
+const multiCache = cacheManager.multiCaching([sqliteCache, redisCache])
+
+// Basic get/set
+await multiCache.set('foo2', 'bar2', { ttl: customTTL })
+const v = await multiCache.get('foo2')
+
+// Wrap call example
+const userId = 'user-1'
+
+// Optionally pass ttl
+await multiCache.wrap(userId, { ttl: customTTL }, async () => {
+    console.log("Calling expensive service")
+    await getUserFromExpensiveService(userId)
+})
+
+// set and get multiple
+await multiCache.mset('foo1', 'bar1', 'foo0', 'bar0') //Uses default TTL
+await multiCache.mset('foo1', 'bar1', 'foo3', 'bar3', {ttl: customTTL})
+await multiCache.mget('foo1', 'foo3')
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ A modern SQlite cache store for [node-cache-manager](https://github.com/BryanDon
  - `async`/`await` support with Promise
  - 100% test coverage and production ready
  - Optimized `mset`/`mget` support
- - Smart purging support (no configuration required)
+ - CBOR efficient and fast storage
+ - Smart purging support, no configuration required
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ const cacheManager = require('cache-manager')
 const memStoreCache = cacheManager.caching({
     store: sqliteStore,
     serializer: 'cbor', // default is 'json'
-    ttl: 20 // TTL in seconds
+    options: {
+        ttl: 20 // TTL in seconds
+    }
 })
 
 // On disk cache on employees table
@@ -56,7 +58,7 @@ const redisStore = require('cache-manager-ioredis')
 const sqliteStore = require('cache-manager-sqlite')
 
 const redisCache = cacheManager.caching({ store: redisStore, db: 0, ttl: 600 })
-const sqliteCache = cacheManager.caching({ store: sqliteStore, path: '/cache.db', name: 'users', ttl: 600 })
+const sqliteCache = cacheManager.caching({ store: sqliteStore, path: '/cache.db', name: 'users', options{ ttl: 600 } })
 
 const multiCache = cacheManager.multiCaching([sqliteCache, redisCache])
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "cache-manager-sqlite",
-  "version": "0.1.0",
+  "version": "0.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cache-manager-sqlite",
-      "version": "0.1.0",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
+        "cbor-x": "^1.3.1",
         "sqlite3": "^5.0.8"
       },
       "devDependencies": {
@@ -16,6 +17,9 @@
         "mocha": "^10.0.0",
         "nyc": "^15.1.0",
         "sinon": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -411,6 +415,78 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@cbor-extract/cbor-extract-darwin-arm64": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-arm64/-/cbor-extract-darwin-arm64-2.0.0.tgz",
+      "integrity": "sha512-jebtLrruvsBbGMsUn0QxZW/8Z7caS9OkszVKZ64WTWajUkyohmolUdKL2nbfaTyyi3ABJrxVNM4YO1pvMsNI1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-darwin-x64": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-x64/-/cbor-extract-darwin-x64-2.0.0.tgz",
+      "integrity": "sha512-LGYjdlyqANBqCDzBujCqXpPcK70rvaQgw98/aquzBuEmK0KXS7i579CoVG1yS/eb3bMqiVPevBri45jbR6Tlsg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-arm": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm/-/cbor-extract-linux-arm-2.0.0.tgz",
+      "integrity": "sha512-cOGHEIif5rPbpix6qhpuatrZzm6HeC5rT0nXt8ynLTc7PzfXmovswD9x6d9h5NcHswkV5y3PbkNbpel/tLADYg==",
+      "cpu": [
+        "arm"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-arm64": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm64/-/cbor-extract-linux-arm64-2.0.0.tgz",
+      "integrity": "sha512-c1rbQcSF01yVgbG60zEfHNsUkXiEEQRNdYqm5qpqEAkLx4gA6DDU91IQbalkqXfwDuQzcMovOc1TC3uJJIi2OQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-x64": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-x64/-/cbor-extract-linux-x64-2.0.0.tgz",
+      "integrity": "sha512-WYeE1b5WGf9pbbQH3qeNBXq710gGsuVFUiP148RY8In+2pCp/fxjBpe701ngam9/fF5D+gJs8B1i5wv/PN7JZA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-win32-x64": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-win32-x64/-/cbor-extract-win32-x64-2.0.0.tgz",
+      "integrity": "sha512-XqVuJEnE0jpl/RkuSp04FF2UE73gY52Y4nZaIE6j9GAeSH2cHYU5CCd4TaVMDi2M18ZpZv7XhL/k+nneQzyJpQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
@@ -960,6 +1036,32 @@
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
         }
       ]
+    },
+    "node_modules/cbor-extract": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/cbor-extract/-/cbor-extract-2.0.2.tgz",
+      "integrity": "sha512-QoLGEgPff03ad/L66P91ci5Zmf7Woq8bh4H5XT3+D5annlrPH5ObHf2Yvo53eDQaDkQtF9tJwMKSWANGXDmwUA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.0.3"
+      },
+      "optionalDependencies": {
+        "@cbor-extract/cbor-extract-darwin-arm64": "2.0.0",
+        "@cbor-extract/cbor-extract-darwin-x64": "2.0.0",
+        "@cbor-extract/cbor-extract-linux-arm": "2.0.0",
+        "@cbor-extract/cbor-extract-linux-arm64": "2.0.0",
+        "@cbor-extract/cbor-extract-linux-x64": "2.0.0",
+        "@cbor-extract/cbor-extract-win32-x64": "2.0.0"
+      }
+    },
+    "node_modules/cbor-x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/cbor-x/-/cbor-x-1.3.1.tgz",
+      "integrity": "sha512-SqCzL9r7Q5QpIgvlr2vla/Y23lPQehftVtUTGNEEMGNpWg0embqg9dxi8dfhuiPWTsQTcT09LgJ9xf2/nZUMZA==",
+      "optionalDependencies": {
+        "cbor-extract": "^2.0.2"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2307,6 +2409,17 @@
       },
       "engines": {
         "node": ">= 10.12.0"
+      }
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
+      "integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==",
+      "optional": true,
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
       }
     },
     "node_modules/node-gyp/node_modules/are-we-there-yet": {
@@ -3803,6 +3916,42 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@cbor-extract/cbor-extract-darwin-arm64": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-arm64/-/cbor-extract-darwin-arm64-2.0.0.tgz",
+      "integrity": "sha512-jebtLrruvsBbGMsUn0QxZW/8Z7caS9OkszVKZ64WTWajUkyohmolUdKL2nbfaTyyi3ABJrxVNM4YO1pvMsNI1g==",
+      "optional": true
+    },
+    "@cbor-extract/cbor-extract-darwin-x64": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-x64/-/cbor-extract-darwin-x64-2.0.0.tgz",
+      "integrity": "sha512-LGYjdlyqANBqCDzBujCqXpPcK70rvaQgw98/aquzBuEmK0KXS7i579CoVG1yS/eb3bMqiVPevBri45jbR6Tlsg==",
+      "optional": true
+    },
+    "@cbor-extract/cbor-extract-linux-arm": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm/-/cbor-extract-linux-arm-2.0.0.tgz",
+      "integrity": "sha512-cOGHEIif5rPbpix6qhpuatrZzm6HeC5rT0nXt8ynLTc7PzfXmovswD9x6d9h5NcHswkV5y3PbkNbpel/tLADYg==",
+      "optional": true
+    },
+    "@cbor-extract/cbor-extract-linux-arm64": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm64/-/cbor-extract-linux-arm64-2.0.0.tgz",
+      "integrity": "sha512-c1rbQcSF01yVgbG60zEfHNsUkXiEEQRNdYqm5qpqEAkLx4gA6DDU91IQbalkqXfwDuQzcMovOc1TC3uJJIi2OQ==",
+      "optional": true
+    },
+    "@cbor-extract/cbor-extract-linux-x64": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-x64/-/cbor-extract-linux-x64-2.0.0.tgz",
+      "integrity": "sha512-WYeE1b5WGf9pbbQH3qeNBXq710gGsuVFUiP148RY8In+2pCp/fxjBpe701ngam9/fF5D+gJs8B1i5wv/PN7JZA==",
+      "optional": true
+    },
+    "@cbor-extract/cbor-extract-win32-x64": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-win32-x64/-/cbor-extract-win32-x64-2.0.0.tgz",
+      "integrity": "sha512-XqVuJEnE0jpl/RkuSp04FF2UE73gY52Y4nZaIE6j9GAeSH2cHYU5CCd4TaVMDi2M18ZpZv7XhL/k+nneQzyJpQ==",
+      "optional": true
+    },
     "@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
@@ -4233,6 +4382,29 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001364.tgz",
       "integrity": "sha512-9O0xzV3wVyX0SlegIQ6knz+okhBB5pE0PC40MNdwcipjwpxoUEHL24uJ+gG42cgklPjfO5ZjZPme9FTSN3QT2Q==",
       "dev": true
+    },
+    "cbor-extract": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/cbor-extract/-/cbor-extract-2.0.2.tgz",
+      "integrity": "sha512-QoLGEgPff03ad/L66P91ci5Zmf7Woq8bh4H5XT3+D5annlrPH5ObHf2Yvo53eDQaDkQtF9tJwMKSWANGXDmwUA==",
+      "optional": true,
+      "requires": {
+        "@cbor-extract/cbor-extract-darwin-arm64": "2.0.0",
+        "@cbor-extract/cbor-extract-darwin-x64": "2.0.0",
+        "@cbor-extract/cbor-extract-linux-arm": "2.0.0",
+        "@cbor-extract/cbor-extract-linux-arm64": "2.0.0",
+        "@cbor-extract/cbor-extract-linux-x64": "2.0.0",
+        "@cbor-extract/cbor-extract-win32-x64": "2.0.0",
+        "node-gyp-build-optional-packages": "5.0.3"
+      }
+    },
+    "cbor-x": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/cbor-x/-/cbor-x-1.3.1.tgz",
+      "integrity": "sha512-SqCzL9r7Q5QpIgvlr2vla/Y23lPQehftVtUTGNEEMGNpWg0embqg9dxi8dfhuiPWTsQTcT09LgJ9xf2/nZUMZA==",
+      "requires": {
+        "cbor-extract": "^2.0.2"
+      }
     },
     "chalk": {
       "version": "4.1.2",
@@ -5277,6 +5449,12 @@
           }
         }
       }
+    },
+    "node-gyp-build-optional-packages": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.0.3.tgz",
+      "integrity": "sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==",
+      "optional": true
     },
     "node-preload": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "author": "Zohaib Sibte Hassan",
   "license": "MIT",
   "dependencies": {
+    "cbor-x": "^1.3.1",
     "sqlite3": "^5.0.8"
   },
   "devDependencies": {

--- a/serializers.js
+++ b/serializers.js
@@ -1,0 +1,13 @@
+const cbor = require('cbor-x')
+
+module.exports = {
+    json: {
+        serialize: o => JSON.stringify(o),
+        deserialize: p => JSON.parse(p)
+    },
+
+    cbor: {
+        serialize: o => cbor.encode(o),
+        deserialize: p => cbor.decode(p)
+    }
+}

--- a/test/cache-manager.test.js
+++ b/test/cache-manager.test.js
@@ -51,6 +51,12 @@ describe('cacheManager callback', () => {
             done(err)
         })
     })
+
+    it('mset sets multiple values with TTL', (done) => {
+        cache.mset('goo1', 1, 'goo2', 2, 'goo3', 3, {ttl: 10}, (err) => {
+            done(err)
+        })
+    })
 })
 
 describe('cacheManager promised', () => {

--- a/test/cache-manager.test.js
+++ b/test/cache-manager.test.js
@@ -55,7 +55,8 @@ describe('cacheManager callback', () => {
 
 describe('cacheManager promised', () => {
     const cache = cacheManager.caching({
-        store: sqliteStore
+        store: sqliteStore,
+        path: '/tmp/test1.db'
     })
 
     it('set should serialized bad object to null', async () => {
@@ -148,8 +149,8 @@ describe('cacheManager promised', () => {
     })
 
     it('mset respects ttl if passed', async () => {
-        await cache.mset('goo1', 1, 'goo2', 2, 'goo3', 3, {ttl: -1})
-        const rs = await cache.mget(['goo1', 'goo2', 'goo3'])
+        await cache.mset('too1', 1, 'too2', 2, 'too3', 3, {ttl: -1})
+        const rs = await cache.mget(['too1', 'too2', 'too3'])
         assert.deepEqual(rs, [])
     })
 })

--- a/test/serializers.test.js
+++ b/test/serializers.test.js
@@ -1,0 +1,56 @@
+const assert = require('assert')
+const cacheManager = require('cache-manager')
+const sqliteStore = require('../index')
+
+describe('cacheManager serializers', () => {
+    it('supports CBOR', async () => {
+        const cache = cacheManager.caching({
+            store: sqliteStore,
+            options: { serializer: 'cbor' }
+        })
+
+        await cache.set("foo", {foo: "bar", arr: [1, true, null]})
+        assert.deepEqual(await cache.get("foo"), {foo: "bar", arr: [1, true, null]})
+    })
+
+    it('supports JSON', async () => {
+        const cache = cacheManager.caching({
+            store: sqliteStore,
+            options: { serializer: 'json' }
+        })
+
+        await cache.set("foo", {foo: "bar", arr: [1, true, null]})
+        assert.deepEqual(await cache.get("foo"), {foo: "bar", arr: [1, true, null]})
+    })
+})
+
+describe('cacheManager custom serializers', () => {
+    it('Bad serializer does not save', async () => {
+        const cache = cacheManager.caching({
+            store: sqliteStore,
+            options: { 
+                serializer: {
+                    serialize: () => { 
+                        throw new Error('Fake error') 
+                    },
+                    deserialize: () => {
+                        throw new Error('Fake error') 
+                    }
+                }
+            }
+        })
+
+        await cache.set("foo", {foo: "bar", arr: [1, true, null]})
+        assert.deepEqual(await cache.get("foo"), null)
+    })
+
+    it('supports JSON', async () => {
+        const cache = cacheManager.caching({
+            store: sqliteStore,
+            options: { serializer: 'json' }
+        })
+
+        await cache.set("foo", {foo: "bar", arr: [1, true, null]})
+        assert.deepEqual(await cache.get("foo"), {foo: "bar", arr: [1, true, null]})
+    })
+})


### PR DESCRIPTION
This change achieves various big goals including:

- Support for serialization protocol (now supports CBOR as serializer)
- Many documentation fixes and updates including TTL
- Move TTL from milliseconds to seconds as per cache manager requirements
- set now uses mset reusing same code